### PR TITLE
Fix ledger close header button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed ledger connect header close button not working](https://github.com/multiversx/mx-sdk-dapp-ui/pull/129)
 - [Fixed the ExplorerLink shadow DOM status and layout](https://github.com/multiversx/mx-sdk-dapp-ui/pull/128)
 - [Updated the Ledger mobile layout and converted styles to Tailwind](https://github.com/multiversx/mx-sdk-dapp-ui/pull/127)
 - [Removed Satoshi font and allow custom fonts from dApp](https://github.com/multiversx/mx-sdk-dapp-ui/pull/125)

--- a/src/components/functional/ledger-connect/ledger-connect.tsx
+++ b/src/components/functional/ledger-connect/ledger-connect.tsx
@@ -72,11 +72,19 @@ export class LedgerConnect {
     this.eventBus.publish(LedgerConnectEventsEnum.CONNECT_DEVICE);
   }
 
+  private handleClose() {
+    this.eventBus.publish(LedgerConnectEventsEnum.CLOSE);
+  }
+
   render() {
     if (this.ledgerDataState.accountScreenData) {
       return (
         <Fragment>
-          <mvx-side-panel-header panelTitle={providerLabels.ledger} hasLeftButton={false} />
+          <mvx-side-panel-header
+            panelTitle={providerLabels.ledger}
+            hasLeftButton={false}
+            onRightButtonClick={this.handleClose.bind(this)}
+          />
 
           <mvx-ledger-addresses
             selectedIndex={this.selectedIndex}
@@ -94,7 +102,11 @@ export class LedgerConnect {
     if (this.ledgerDataState.confirmScreenData) {
       return (
         <Fragment>
-          <mvx-side-panel-header panelTitle={providerLabels.ledger} hasLeftButton={false} />
+          <mvx-side-panel-header
+            panelTitle={providerLabels.ledger}
+            hasLeftButton={false}
+            onRightButtonClick={this.handleClose.bind(this)}
+          />
           <mvx-ledger-confirm confirmScreenData={this.ledgerDataState.confirmScreenData} />
         </Fragment>
       );
@@ -102,7 +114,11 @@ export class LedgerConnect {
 
     return (
       <Fragment>
-        <mvx-side-panel-header panelTitle={providerLabels.ledger} hasLeftButton={false} />
+        <mvx-side-panel-header
+          panelTitle={providerLabels.ledger}
+          hasLeftButton={false}
+          onRightButtonClick={this.handleClose.bind(this)}
+        />
 
         <mvx-ledger-intro
           connectScreenData={this.ledgerDataState.connectScreenData}


### PR DESCRIPTION
### Issue

Ledger connect component close button not working when mounted into unlock panel. When users click the close button (X) in the side panel header of the ledger connect component, the action is not registered in the unlock panel and nothing happens.

### Reproduce

1. Open the unlock panel
2. Select Ledger as the connection method
3. Click the close button (X) in the top-right corner of the ledger connect panel
4. **Expected**: Panel should close and return to unlock panel
5. **Actual**: Nothing happens, panel remains open


### Root cause

The ledger connect component was using `this.close.emit` for the close button action, which emits a Stencil component event that wasn't being handled by the unlock panel. The unlock panel expects to receive an `ANCHOR_CLOSE` event from the anchor element, but the ledger connect component wasn't publishing the proper event to trigger this flow.

**Event Flow Gap:**
- Ledger connect component → `this.close.emit` (Stencil event) → No handler in unlock panel
- Expected flow: Ledger connect component → Event bus `CLOSE` event → LedgerConnectStateManager → `ANCHOR_CLOSE` event → Unlock panel handler

**Missing Event Bus Integration:**
While other actions in the ledger connect component (like `accessWallet()` and `handleIntroConnect()`) were properly publishing events to the event bus, the close action wasn't following the same pattern.

### Fix

1. **Added `handleClose()` method** to the ledger connect component that publishes a `CLOSE` event to the event bus:
   ```typescript
   private handleClose() {
     this.eventBus.publish(LedgerConnectEventsEnum.CLOSE);
   }
   ```

2. **Updated all three instances** of `mvx-side-panel-header` in the component to use `onRightButtonClick={this.handleClose.bind(this)}` instead of `this.close.emit`:
   - Account screen state
   - Confirm screen state  
   - Intro screen state

3. **Ensured consistent behavior** across all render states of the ledger connect component.

### Additional changes

None.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests

**Test Steps:**
1. Open unlock panel
2. Select Ledger connection method
3. Verify close button (X) properly closes the ledger connect panel and returns to unlock panel
4. Test close button functionality in all three states: intro screen, account selection screen, and confirm screen