### PR TITLE
Updated variables for switching the theme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Updated variables for switching the theme.](https://github.com/multiversx/mx-sdk-dapp-ui/pull/134)
 
 ## [[0.0.7](https://github.com/multiversx/mx-sdk-dapp-ui/pull/130)] - 2025-06-23
 

--- a/src/global/variables.css
+++ b/src/global/variables.css
@@ -49,107 +49,88 @@
   --mvx-blue-600: #007bff;
   --mvx-blue-700: #0062cc;
   --mvx-cyan-500: #17a2b8;
+}
 
-  /* Light Theme Variables */
-  --mvx-text-color-primary: var(--mvx-black);
-  --mvx-text-color-secondary: var(--mvx-stone-450);
-  --mvx-text-color-tertiary: var(--mvx-neutral-800);
-  --mvx-text-accent-color: var(--mvx-black);
-  --mvx-label-color: var(--mvx-neutral-450);
-
-  --mvx-bg-color-primary: var(--mvx-neutral-100);
-  --mvx-bg-color-secondary: var(--mvx-white);
-  --mvx-bg-color-tertiary: var(--mvx-white);
-  --mvx-bg-accent-color: var(--mvx-white);
-  --mvx-bg-accent-variant-color: var(--mvx-stone-100);
-
-  --mvx-hover-color-primary: var(--mvx-neutral-200);
-  --mvx-hover-bg-primary: var(--mvx-black);
-
-  --mvx-border-color-primary: var(--mvx-neutral-200);
-
-  --mvx-button-bg-primary: var(--mvx-black);
-  --mvx-button-text-primary: var(--mvx-white);
-  --mvx-button-bg-secondary: var(--mvx-white);
-  --mvx-button-text-secondary: var(--mvx-neutral-800);
-
-  --mvx-select-bg: var(--mvx-white);
-  --mvx-select-color: var(--mvx-neutral-700);
-  --mvx-select-option-color: var(--mvx-black);
-  --mvx-select-option-bg: var(--mvx-neutral-400);
-  --mvx-select-option-bg-mobile: var(--mvx-neutral-400);
-
-  --mvx-success-color: var(--mvx-white);
-  --mvx-success-bg-color: var(--mvx-green-600);
-  --mvx-pending-color: var(--mvx-yellow-400);
-  --mvx-pending-bg-color: var(--mvx-brown-900);
-  --mvx-error-color: var(--mvx-red-400);
-  --mvx-error-bg-color: var(--mvx-red-900);
-
-  --mvx-pagination-item-bg: var(--mvx-neutral-200);
-  --mvx-pagination-item-bg-hover: var(--mvx-neutral-400);
-
-  --mvx-preloader-bg: var(--mvx-neutral-400);
-  --mvx-preloader-item-bg: var(--mvx-neutral-200);
-
-  --mvx-warning-text: var(--mvx-amber-650);
-
-  --mvx-link-color: var(--mvx-neutral-700);
-
-  --mvx-progress-color: var(--mvx-gray-350);
-  --mvx-progress-accent-color: var(--mvx-black);
-
-  --mvx-icon-bg: var(--mvx-neutral-350);
 
   /* Dark Theme Variables */
+:root, :root[data-theme="mvx:dark-theme"] {
   --mvx-text-color-primary: var(--mvx-white);
   --mvx-text-color-secondary: var(--mvx-stone-350);
   --mvx-text-color-tertiary: var(--mvx-neutral-200);
   --mvx-text-accent-color: var(--mvx-teal-400);
   --mvx-label-color: var(--mvx-neutral-400);
-
   --mvx-bg-color-primary: var(--mvx-neutral-900);
   --mvx-bg-color-secondary: var(--mvx-neutral-920);
   --mvx-bg-color-tertiary: var(--mvx-neutral-910);
   --mvx-bg-accent-color: var(--mvx-neutral-950);
   --mvx-bg-accent-variant-color: var(--mvx-neutral-950);
-
   --mvx-hover-color-primary: var(--mvx-neutral-800);
   --mvx-hover-bg-primary: var(--mvx-white);
-
   --mvx-border-color-primary: var(--mvx-neutral-800);
-
   --mvx-button-bg-primary: var(--mvx-teal-400);
   --mvx-button-text-primary: var(--mvx-black);
   --mvx-button-bg-secondary: var(--mvx-neutral-800);
   --mvx-button-text-secondary: var(--mvx-neutral-200);
   --mvx-button-bg-hover-secondary: var(--mvx-teal-400);
-
   --mvx-select-bg: var(--mvx-neutral-800);
   --mvx-select-color: var(--mvx-gray-200);
   --mvx-select-option-color: var(--mvx-teal-200);
   --mvx-select-option-bg: var(--mvx-black);
   --mvx-select-option-bg-mobile: var(--mvx-zinc-800);
-
   --mvx-success-color: var(--mvx-green-400);
   --mvx-success-bg-color: var(--mvx-green-850);
   --mvx-pending-color: var(--mvx-yellow-400);
   --mvx-pending-bg-color: var(--mvx-brown-900);
   --mvx-error-color: var(--mvx-red-400);
   --mvx-error-bg-color: var(--mvx-red-900);
-
   --mvx-pagination-item-bg: var(--mvx-neutral-700);
   --mvx-pagination-item-bg-hover: var(--mvx-teal-900);
-
   --mvx-preloader-bg: var(--mvx-neutral-800);
   --mvx-preloader-item-bg: var(--mvx-neutral-700);
-
   --mvx-warning-text: var(--mvx-yellow-400);
-
   --mvx-link-color: var(--mvx-stone-350);
-
   --mvx-progress-color: var(--mvx-gray-650);
   --mvx-progress-accent-color: var(--mvx-teal-400);
-
   --mvx-icon-bg: var(--mvx-gray-750);
+}
+
+/* Light Theme Variables */
+:root[data-theme="mvx:light-theme"] {
+  --mvx-text-color-primary: var(--mvx-black);
+  --mvx-text-color-secondary: var(--mvx-stone-450);
+  --mvx-text-color-tertiary: var(--mvx-neutral-800);
+  --mvx-text-accent-color: var(--mvx-black);
+  --mvx-label-color: var(--mvx-neutral-450);
+  --mvx-bg-color-primary: var(--mvx-neutral-100);
+  --mvx-bg-color-secondary: var(--mvx-white);
+  --mvx-bg-color-tertiary: var(--mvx-white);
+  --mvx-bg-accent-color: var(--mvx-white);
+  --mvx-bg-accent-variant-color: var(--mvx-stone-100);
+  --mvx-hover-color-primary: var(--mvx-neutral-200);
+  --mvx-hover-bg-primary: var(--mvx-black);
+  --mvx-border-color-primary: var(--mvx-neutral-200);
+  --mvx-button-bg-primary: var(--mvx-black);
+  --mvx-button-text-primary: var(--mvx-white);
+  --mvx-button-bg-secondary: var(--mvx-white);
+  --mvx-button-text-secondary: var(--mvx-neutral-800);
+  --mvx-select-bg: var(--mvx-white);
+  --mvx-select-color: var(--mvx-neutral-700);
+  --mvx-select-option-color: var(--mvx-black);
+  --mvx-select-option-bg: var(--mvx-neutral-400);
+  --mvx-select-option-bg-mobile: var(--mvx-neutral-400);
+  --mvx-success-color: var(--mvx-white);
+  --mvx-success-bg-color: var(--mvx-green-600);
+  --mvx-pending-color: var(--mvx-yellow-400);
+  --mvx-pending-bg-color: var(--mvx-brown-900);
+  --mvx-error-color: var(--mvx-red-400);
+  --mvx-error-bg-color: var(--mvx-red-900);
+  --mvx-pagination-item-bg: var(--mvx-neutral-200);
+  --mvx-pagination-item-bg-hover: var(--mvx-neutral-400);
+  --mvx-preloader-bg: var(--mvx-neutral-400);
+  --mvx-preloader-item-bg: var(--mvx-neutral-200);
+  --mvx-warning-text: var(--mvx-amber-650);
+  --mvx-link-color: var(--mvx-neutral-700);
+  --mvx-progress-color: var(--mvx-gray-350);
+  --mvx-progress-accent-color: var(--mvx-black);
+  --mvx-icon-bg: var(--mvx-neutral-350);
 }


### PR DESCRIPTION
### Feature
Updated the root variables for switching the themes between light and dark, that will hook onto the `data-theme` of the user application root. This feature don't exist on `v0.0.7` of `sdk-dapp-ui`. 

### Contains Breaking Changes
- [x] No
- [ ] Yes

### Updated CHANGELOG.md
- [x] Yes
- [ ] No

### Testing
- [x] User testing
- [ ] Unit tests
