### PR TITLE
Fixed icons max width / height in toasts.

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -58,8 +58,14 @@ export namespace Components {
     interface MvxCloseIcon {
     }
     interface MvxCopyButton {
+        /**
+          * @default 'copy-button'
+         */
         "class"?: string;
         "copyIcon"?: IconDefinition | string;
+        /**
+          * @default 'copy-button-icon'
+         */
         "iconClass"?: string;
         "successIcon"?: IconDefinition | string;
         "text": string;
@@ -85,6 +91,9 @@ export namespace Components {
         "width"?: number;
     }
     interface MvxFaIcon {
+        /**
+          * @default 'fa-icon'
+         */
         "class"?: string;
         "description"?: string;
         "icon": IconDefinition | string;
@@ -96,6 +105,9 @@ export namespace Components {
         "isValid": boolean;
         "label"?: string;
         "labelClass"?: string;
+        /**
+          * @default true
+         */
         "showLabel"?: boolean;
         "valueDecimal": string;
         "valueInteger": string;
@@ -111,6 +123,9 @@ export namespace Components {
         "confirmScreenData": IConfirmScreenData;
     }
     interface MvxLedgerConnect {
+        /**
+          * @default {     accountScreenData: null,     confirmScreenData: null,     connectScreenData: {},   }
+         */
         "data": ILedgerConnectPanelData;
         "getEventBus": () => Promise<IEventBus>;
     }
@@ -119,6 +134,9 @@ export namespace Components {
     }
     interface MvxLedgerIntro {
         "connectScreenData"?: IConnectScreenData;
+        /**
+          * @default false
+         */
         "isAwaiting"?: boolean;
     }
     interface MvxLedgerProviderIcon {
@@ -139,14 +157,26 @@ export namespace Components {
     }
     interface MvxPagination {
         "class"?: string;
+        /**
+          * @default 1
+         */
         "currentPage": number;
+        /**
+          * @default false
+         */
         "isDisabled"?: boolean;
         "totalPages": number;
     }
     interface MvxPaginationEllipsis {
+        /**
+          * @default false
+         */
         "isActive": boolean;
     }
     interface MvxPaginationEllipsisForm {
+        /**
+          * @default false
+         */
         "isVisible": boolean;
         "maxPageToSearchFor": number;
     }
@@ -164,27 +194,54 @@ export namespace Components {
         "class"?: string;
     }
     interface MvxProviderIdleScreen {
+        /**
+          * @default ''
+         */
         "introText": string;
+        /**
+          * @default 'Requesting Connection'
+         */
         "introTitle": string;
+        /**
+          * @default null
+         */
         "provider": IProviderBase | null;
     }
     interface MvxSidePanel {
         "hasBackButton"?: boolean;
+        /**
+          * @default false
+         */
         "isOpen": boolean;
         "panelClassName"?: string;
         "panelTitle": string;
+        /**
+          * @default true
+         */
         "showHeader"?: boolean;
     }
     interface MvxSidePanelHeader {
+        /**
+          * @default true
+         */
         "hasLeftButton"?: boolean;
+        /**
+          * @default true
+         */
         "hasRightButton"?: boolean;
         "panelClassName"?: string;
         "panelTitle": string;
     }
     interface MvxSidePanelSwiper {
         "close": () => Promise<void>;
+        /**
+          * @default false
+         */
         "open": boolean;
         "openToSnapPoint": (snapIndex?: number) => Promise<void>;
+        /**
+          * @default ''
+         */
         "sidePanelIdentifier": string;
     }
     interface MvxSignTransactionsAdvanced {
@@ -196,7 +253,13 @@ export namespace Components {
         "highlight"?: string;
     }
     interface MvxSignTransactionsAdvancedDataDecode {
+        /**
+          * @default DecodeMethodEnum.decimal
+         */
         "currentDecodeMethod": DecodeMethodEnum;
+        /**
+          * @default false
+         */
         "isToggled": boolean;
     }
     interface MvxSignTransactionsFooter {
@@ -209,7 +272,13 @@ export namespace Components {
         "identifier": string;
         "interactor": string;
         "interactorIconUrl": string;
+        /**
+          * @default false
+         */
         "isApp": boolean;
+        /**
+          * @default '~$0.00078'
+         */
         "networkFee": string;
         "tokenIconUrl": string;
         "usdValue": string;
@@ -238,8 +307,14 @@ export namespace Components {
     }
     interface MvxTooltip {
         "class"?: string;
+        /**
+          * @default 'top'
+         */
         "position": 'top' | 'bottom';
         "trigger": HTMLElement;
+        /**
+          * @default false
+         */
         "triggerOnClick"?: boolean;
     }
     interface MvxTransactionAccount {
@@ -247,6 +322,9 @@ export namespace Components {
         "class"?: string;
         "dataTestId"?: string;
         "scope": 'receiver' | 'sender';
+        /**
+          * @default false
+         */
         "showLockedAccounts": boolean;
     }
     interface MvxTransactionAccountName {
@@ -291,10 +369,19 @@ export namespace Components {
     }
     interface MvxTransactionToast {
         "fullWidth"?: boolean;
+        /**
+          * @default ''
+         */
         "processedTransactionsStatus": string | JSX.Element;
         "toastDataState": IToastDataState;
+        /**
+          * @default ''
+         */
         "toastId": string;
         "transactionProgressState"?: ITransactionProgressState;
+        /**
+          * @default []
+         */
         "transactions": ITransactionListItem[];
         "wrapperClass": string;
     }
@@ -305,6 +392,9 @@ export namespace Components {
         "transactions": ITransactionListItem[];
     }
     interface MvxTransactionToastDetails {
+        /**
+          * @default 5
+         */
         "maxShownTransactions": number;
         "processedTransactionsStatus"?: string | JSX.Element;
         "transactionClass": string;
@@ -315,6 +405,9 @@ export namespace Components {
         "index": string;
         "link": string;
         "status"?: string;
+        /**
+          * @default 'transaction-details-list-item'
+         */
         "transactionClass"?: string;
     }
     interface MvxTransactionToastProgress {
@@ -352,6 +445,9 @@ export namespace Components {
     }
     interface MvxUnlockPanelGroup {
         "class"?: string;
+        /**
+          * @default []
+         */
         "providers": IProviderBase[];
     }
     interface MvxUnlockProviderButton {
@@ -359,8 +455,14 @@ export namespace Components {
         "provider": IProviderBase<ProviderTypeEnum>;
     }
     interface MvxWalletConnect {
+        /**
+          * @default { wcURI: '' }
+         */
         "data": IWalletConnectPanelData;
         "getEventBus": () => Promise<IEventBus>;
+        /**
+          * @default ''
+         */
         "qrCodeSvg": string;
     }
     interface MvxWalletConnectAppGalleryIcon {
@@ -377,7 +479,13 @@ export namespace Components {
     }
     interface MvxWalletConnectScan {
         "class"?: string;
+        /**
+          * @default ''
+         */
         "qrCodeSvg": string;
+        /**
+          * @default ''
+         */
         "walletConnectDeepLink"?: string;
     }
     interface MvxWalletProviderIcon {
@@ -386,6 +494,9 @@ export namespace Components {
     interface MvxXaliasProviderIcon {
     }
     interface MvxXportalDownloadQrIcon {
+        /**
+          * @default ''
+         */
         "class"?: string;
     }
     interface MvxXportalQrCodePreloader {
@@ -1276,8 +1387,14 @@ declare namespace LocalJSX {
     interface MvxCloseIcon {
     }
     interface MvxCopyButton {
+        /**
+          * @default 'copy-button'
+         */
         "class"?: string;
         "copyIcon"?: IconDefinition | string;
+        /**
+          * @default 'copy-button-icon'
+         */
         "iconClass"?: string;
         "successIcon"?: IconDefinition | string;
         "text"?: string;
@@ -1304,6 +1421,9 @@ declare namespace LocalJSX {
         "width"?: number;
     }
     interface MvxFaIcon {
+        /**
+          * @default 'fa-icon'
+         */
         "class"?: string;
         "description"?: string;
         "icon"?: IconDefinition | string;
@@ -1315,6 +1435,9 @@ declare namespace LocalJSX {
         "isValid"?: boolean;
         "label"?: string;
         "labelClass"?: string;
+        /**
+          * @default true
+         */
         "showLabel"?: boolean;
         "valueDecimal"?: string;
         "valueInteger"?: string;
@@ -1334,6 +1457,9 @@ declare namespace LocalJSX {
         "confirmScreenData"?: IConfirmScreenData;
     }
     interface MvxLedgerConnect {
+        /**
+          * @default {     accountScreenData: null,     confirmScreenData: null,     connectScreenData: {},   }
+         */
         "data"?: ILedgerConnectPanelData;
     }
     interface MvxLedgerIcon {
@@ -1341,6 +1467,9 @@ declare namespace LocalJSX {
     }
     interface MvxLedgerIntro {
         "connectScreenData"?: IConnectScreenData;
+        /**
+          * @default false
+         */
         "isAwaiting"?: boolean;
         "onConnect"?: (event: MvxLedgerIntroCustomEvent<any>) => void;
     }
@@ -1360,15 +1489,27 @@ declare namespace LocalJSX {
     }
     interface MvxPagination {
         "class"?: string;
+        /**
+          * @default 1
+         */
         "currentPage"?: number;
+        /**
+          * @default false
+         */
         "isDisabled"?: boolean;
         "onPageChange"?: (event: MvxPaginationCustomEvent<number>) => void;
         "totalPages"?: number;
     }
     interface MvxPaginationEllipsis {
+        /**
+          * @default false
+         */
         "isActive"?: boolean;
     }
     interface MvxPaginationEllipsisForm {
+        /**
+          * @default false
+         */
         "isVisible"?: boolean;
         "maxPageToSearchFor"?: number;
         "onSearch"?: (event: MvxPaginationEllipsisFormCustomEvent<number>) => void;
@@ -1385,23 +1526,44 @@ declare namespace LocalJSX {
         "class"?: string;
     }
     interface MvxProviderIdleScreen {
+        /**
+          * @default ''
+         */
         "introText"?: string;
+        /**
+          * @default 'Requesting Connection'
+         */
         "introTitle"?: string;
         "onAccess"?: (event: MvxProviderIdleScreenCustomEvent<any>) => void;
         "onClose"?: (event: MvxProviderIdleScreenCustomEvent<any>) => void;
+        /**
+          * @default null
+         */
         "provider"?: IProviderBase | null;
     }
     interface MvxSidePanel {
         "hasBackButton"?: boolean;
+        /**
+          * @default false
+         */
         "isOpen"?: boolean;
         "onBack"?: (event: MvxSidePanelCustomEvent<void>) => void;
         "onClose"?: (event: MvxSidePanelCustomEvent<void>) => void;
         "panelClassName"?: string;
         "panelTitle"?: string;
+        /**
+          * @default true
+         */
         "showHeader"?: boolean;
     }
     interface MvxSidePanelHeader {
+        /**
+          * @default true
+         */
         "hasLeftButton"?: boolean;
+        /**
+          * @default true
+         */
         "hasRightButton"?: boolean;
         "onLeftButtonClick"?: (event: MvxSidePanelHeaderCustomEvent<any>) => void;
         "onRightButtonClick"?: (event: MvxSidePanelHeaderCustomEvent<any>) => void;
@@ -1411,7 +1573,13 @@ declare namespace LocalJSX {
     interface MvxSidePanelSwiper {
         "onSheetDismiss"?: (event: MvxSidePanelSwiperCustomEvent<void>) => void;
         "onSheetSnapChange"?: (event: MvxSidePanelSwiperCustomEvent<{ index: number; snapPoint: string }>) => void;
+        /**
+          * @default false
+         */
         "open"?: boolean;
+        /**
+          * @default ''
+         */
         "sidePanelIdentifier"?: string;
     }
     interface MvxSignTransactionsAdvanced {
@@ -1423,7 +1591,13 @@ declare namespace LocalJSX {
         "highlight"?: string;
     }
     interface MvxSignTransactionsAdvancedDataDecode {
+        /**
+          * @default DecodeMethodEnum.decimal
+         */
         "currentDecodeMethod"?: DecodeMethodEnum;
+        /**
+          * @default false
+         */
         "isToggled"?: boolean;
     }
     interface MvxSignTransactionsFooter {
@@ -1436,7 +1610,13 @@ declare namespace LocalJSX {
         "identifier"?: string;
         "interactor"?: string;
         "interactorIconUrl"?: string;
+        /**
+          * @default false
+         */
         "isApp"?: boolean;
+        /**
+          * @default '~$0.00078'
+         */
         "networkFee"?: string;
         "tokenIconUrl"?: string;
         "usdValue"?: string;
@@ -1464,8 +1644,14 @@ declare namespace LocalJSX {
     interface MvxTooltip {
         "class"?: string;
         "onTriggerRender"?: (event: MvxTooltipCustomEvent<boolean>) => void;
+        /**
+          * @default 'top'
+         */
         "position"?: 'top' | 'bottom';
         "trigger"?: HTMLElement;
+        /**
+          * @default false
+         */
         "triggerOnClick"?: boolean;
     }
     interface MvxTransactionAccount {
@@ -1473,6 +1659,9 @@ declare namespace LocalJSX {
         "class"?: string;
         "dataTestId"?: string;
         "scope"?: 'receiver' | 'sender';
+        /**
+          * @default false
+         */
         "showLockedAccounts"?: boolean;
     }
     interface MvxTransactionAccountName {
@@ -1518,10 +1707,19 @@ declare namespace LocalJSX {
     interface MvxTransactionToast {
         "fullWidth"?: boolean;
         "onDeleteToast"?: (event: MvxTransactionToastCustomEvent<void>) => void;
+        /**
+          * @default ''
+         */
         "processedTransactionsStatus"?: string | JSX.Element;
         "toastDataState"?: IToastDataState;
+        /**
+          * @default ''
+         */
         "toastId"?: string;
         "transactionProgressState"?: ITransactionProgressState;
+        /**
+          * @default []
+         */
         "transactions"?: ITransactionListItem[];
         "wrapperClass"?: string;
     }
@@ -1533,6 +1731,9 @@ declare namespace LocalJSX {
         "transactions"?: ITransactionListItem[];
     }
     interface MvxTransactionToastDetails {
+        /**
+          * @default 5
+         */
         "maxShownTransactions"?: number;
         "processedTransactionsStatus"?: string | JSX.Element;
         "transactionClass"?: string;
@@ -1543,6 +1744,9 @@ declare namespace LocalJSX {
         "index"?: string;
         "link"?: string;
         "status"?: string;
+        /**
+          * @default 'transaction-details-list-item'
+         */
         "transactionClass"?: string;
     }
     interface MvxTransactionToastProgress {
@@ -1579,6 +1783,9 @@ declare namespace LocalJSX {
     interface MvxUnlockPanelGroup {
         "class"?: string;
         "onLogin"?: (event: MvxUnlockPanelGroupCustomEvent<IProviderBase>) => void;
+        /**
+          * @default []
+         */
         "providers"?: IProviderBase[];
     }
     interface MvxUnlockProviderButton {
@@ -1586,7 +1793,13 @@ declare namespace LocalJSX {
         "provider"?: IProviderBase<ProviderTypeEnum>;
     }
     interface MvxWalletConnect {
+        /**
+          * @default { wcURI: '' }
+         */
         "data"?: IWalletConnectPanelData;
+        /**
+          * @default ''
+         */
         "qrCodeSvg"?: string;
     }
     interface MvxWalletConnectAppGalleryIcon {
@@ -1604,7 +1817,13 @@ declare namespace LocalJSX {
     interface MvxWalletConnectScan {
         "class"?: string;
         "onDownloadClick"?: (event: MvxWalletConnectScanCustomEvent<any>) => void;
+        /**
+          * @default ''
+         */
         "qrCodeSvg"?: string;
+        /**
+          * @default ''
+         */
         "walletConnectDeepLink"?: string;
     }
     interface MvxWalletProviderIcon {
@@ -1613,6 +1832,9 @@ declare namespace LocalJSX {
     interface MvxXaliasProviderIcon {
     }
     interface MvxXportalDownloadQrIcon {
+        /**
+          * @default ''
+         */
         "class"?: string;
     }
     interface MvxXportalQrCodePreloader {

--- a/src/components/common/transaction-asset-icon/transaction-asset-icon.scss
+++ b/src/components/common/transaction-asset-icon/transaction-asset-icon.scss
@@ -1,0 +1,5 @@
+:host {
+    .transaction-asset-image {
+        @apply mvx:max-w-full mvx:max-h-full;
+    }
+}

--- a/src/components/common/transaction-asset-icon/transaction-asset-icon.tsx
+++ b/src/components/common/transaction-asset-icon/transaction-asset-icon.tsx
@@ -8,6 +8,7 @@ export enum IconSizeEnumType {
 
 @Component({
   tag: 'mvx-transaction-asset-icon',
+  styleUrl: 'transaction-asset-icon.scss',
   shadow: true,
 })
 export class TransactionAssetIcon {
@@ -24,7 +25,14 @@ export class TransactionAssetIcon {
     }
 
     if (this.transaction.asset.imageUrl) {
-      return <img src={this.transaction.asset.imageUrl} alt="Transaction icon" loading="lazy" />;
+      return (
+        <img
+          src={this.transaction.asset.imageUrl}
+          alt="Transaction icon"
+          loading="lazy"
+          class="transaction-asset-image"
+        />
+      );
     }
 
     if (this.transaction.asset.icon) {

--- a/src/components/functional/toasts-list/components/transaction-toast/components/transaction-toast-details/components/transaction-toast-details-body.scss
+++ b/src/components/functional/toasts-list/components/transaction-toast/components/transaction-toast-details/components/transaction-toast-details-body.scss
@@ -20,7 +20,7 @@
     }
 
     .transaction-details-list-item-copy {
-      @apply mvx:visible;
+      @apply mvx:visible!;
     }
   }
 
@@ -85,7 +85,7 @@
 }
 
 .transaction-details-list-item-copy {
-  @apply mvx:flex mvx:invisible;
+  @apply mvx:flex mvx:invisible!;
 
   .transaction-details-list-item-copy-icon {
     @apply mvx:h-4 mvx:w-4 mvx:flex mvx:flex-col mvx:justify-end mvx:shrink-0 mvx:transition-opacity mvx:duration-200 mvx:ease-in-out ;


### PR DESCRIPTION
### Issue
Icons did not have max-width and max-height set, which caused them to overflow their container.

### Additional changes

### Contains breaking changes
[x] No
[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
