### PR TITLE
Fixed issue with xPortal back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed issue with xPortal back button on login screen](https://github.com/multiversx/mx-sdk-dapp-ui/pull/156)
+
 ## [[0.0.11](https://github.com/multiversx/mx-sdk-dapp-ui/pull/152)] - 2025-07-08
 
 - [UI fixes on scrollbar, icons and unlock panel.](https://github.com/multiversx/mx-sdk-dapp-ui/pull/150)

--- a/src/components/visual/side-panel/components/side-panel-header/side-panel-header.tsx
+++ b/src/components/visual/side-panel/components/side-panel-header/side-panel-header.tsx
@@ -37,9 +37,11 @@ export class SidePanelHeader {
           class={{ 'side-panel-heading-left': true, 'visible': this.hasLeftButton }}
           onClick={this.handleLeftIconClick.bind(this)}
         >
-          <slot name={SidePanelHeaderSlotEnum.leftIcon}>
-            <mvx-back-arrow-icon />
-          </slot>
+          {this.hasLeftButton && (
+            <slot name={SidePanelHeaderSlotEnum.leftIcon}>
+              <mvx-back-arrow-icon />
+            </slot>
+          )}
         </div>
 
         <div class="side-panel-heading-title">{this.panelTitle}</div>


### PR DESCRIPTION
### Issue
- navigating back from download screen of xPortal, it doesn't hide the back button

### Reproduce
Issue exists on version `0.0.11` of sdk-dapp-ui.

### Root cause
- slot is always rendering

### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
