### PR TITLE
Fix issue with icon parsing

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -79,11 +79,17 @@ export namespace Components {
           * @default 'copy-button'
          */
         "class"?: string;
+        /**
+          * @default 'faCopy'
+         */
         "copyIcon"?: IconDefinition | string;
         /**
           * @default 'copy-button-icon'
          */
         "iconClass"?: string;
+        /**
+          * @default 'faCheck'
+         */
         "successIcon"?: IconDefinition | string;
         "text": string;
     }
@@ -1462,11 +1468,17 @@ declare namespace LocalJSX {
           * @default 'copy-button'
          */
         "class"?: string;
+        /**
+          * @default 'faCopy'
+         */
         "copyIcon"?: IconDefinition | string;
         /**
           * @default 'copy-button-icon'
          */
         "iconClass"?: string;
+        /**
+          * @default 'faCheck'
+         */
         "successIcon"?: IconDefinition | string;
         "text"?: string;
     }

--- a/src/components/visual/copy-button/copy-button.tsx
+++ b/src/components/visual/copy-button/copy-button.tsx
@@ -1,8 +1,6 @@
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { Component, h, Prop, State } from '@stencil/core';
 import { copyToClipboard } from 'utils/copyToClipboard';
-import { getIconHtmlFromIconDefinition } from 'utils/icons/getIconHtmlFromIconDefinition';
-import { getIconHtmlFromIconName } from 'utils/icons/getIconHtmlFromIconName';
 
 @Component({
   tag: 'mvx-copy-button',
@@ -11,8 +9,8 @@ import { getIconHtmlFromIconName } from 'utils/icons/getIconHtmlFromIconName';
 export class CopyButton {
   @Prop() class?: string = 'copy-button';
   @Prop() iconClass?: string = 'copy-button-icon';
-  @Prop() copyIcon?: IconDefinition | string;
-  @Prop() successIcon?: IconDefinition | string;
+  @Prop() copyIcon?: IconDefinition | string = 'faCopy';
+  @Prop() successIcon?: IconDefinition | string = 'faCheck';
   @Prop() text: string;
 
   @State() isSuccess: boolean = false;
@@ -44,26 +42,9 @@ export class CopyButton {
   }
 
   render() {
-    let copyIcon = 'faCopy';
-    let successIcon = 'faCheck';
-
-    if (this.copyIcon) {
-      copyIcon =
-        typeof this.copyIcon === 'string'
-          ? getIconHtmlFromIconName(this.copyIcon)
-          : getIconHtmlFromIconDefinition(this.copyIcon);
-    }
-
-    if (this.successIcon) {
-      successIcon =
-        typeof this.successIcon === 'string'
-          ? getIconHtmlFromIconName(this.successIcon)
-          : getIconHtmlFromIconDefinition(this.successIcon);
-    }
-
     return (
       <a href="/#" class={this.class} onClick={this.handleClick}>
-        <mvx-fa-icon icon={this.isSuccess ? successIcon : copyIcon} class={this.iconClass}></mvx-fa-icon>
+        <mvx-fa-icon icon={this.isSuccess ? this.successIcon : this.copyIcon} class={this.iconClass}></mvx-fa-icon>
       </a>
     );
   }


### PR DESCRIPTION
### Issue
<img width="1796" height="572" alt="image" src="https://github.com/user-attachments/assets/05ba297b-9a6d-4e76-8193-96790f9a51de" />


### Reproduce
Issue exists on version `0.0.21` of sdk-dapp-ui.

### Root cause
- double parsing of icon (inside `copy-button` and `fa-icon`)

### Fix
- remove the parser from `copy-button`

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
