### PR TITLE
Fixed issue with toast title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed issue with transaction toast title](https://github.com/multiversx/mx-sdk-dapp-ui/pull/200)
+
 ## [[0.0.25](https://github.com/multiversx/mx-sdk-dapp-ui/pull/199)] - 2025-08-12
 
 - [Fixed issue with transaction toast progress](https://github.com/multiversx/mx-sdk-dapp-ui/pull/198)

--- a/src/components/functional/toasts-list/components/transaction-toast/components/transaction-toast-content/transaction-toast-content.tsx
+++ b/src/components/functional/toasts-list/components/transaction-toast/components/transaction-toast-content/transaction-toast-content.tsx
@@ -63,7 +63,7 @@ export class TransactionToastContent {
                   'transaction-toast-title-short': Boolean(showAmount),
                 }}
               >
-                {transaction?.action?.name || title}
+                {title}
               </h4>
               {showAmount && (
                 <mvx-format-amount


### PR DESCRIPTION
### Issue
- title from sdk-dapp is never used as transaction action name is always defined

### Reproduce
Issue exists on version `0.0.25` of sdk-dapp-ui.

### Root cause

### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
