### PR TITLE
Updated styles on toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Updated styles on toast](https://github.com/multiversx/mx-sdk-dapp-ui/pull/213)
+
 ## [[0.0.27](https://github.com/multiversx/mx-sdk-dapp-ui/pull/209)] - 2025-08-26
 
 - [Added the "DataWithExplorerLink" component and enhanced the "Trim" component](https://github.com/multiversx/mx-sdk-dapp-ui/pull/208)

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -122,6 +122,10 @@ export namespace Components {
           * @default true
          */
         "showExplorerButton"?: boolean;
+        /**
+          * @default false
+         */
+        "withTooltip"?: boolean;
     }
     interface MvxDefaultTransactionIconLarge {
         "class"?: string;
@@ -486,6 +490,9 @@ export namespace Components {
     }
     interface MvxTrim {
         "class"?: string;
+        /**
+          * @default DataTestIdsEnum.trim
+         */
         "dataTestId"?: string;
         "text": string;
     }
@@ -1584,6 +1591,10 @@ declare namespace LocalJSX {
           * @default true
          */
         "showExplorerButton"?: boolean;
+        /**
+          * @default false
+         */
+        "withTooltip"?: boolean;
     }
     interface MvxDefaultTransactionIconLarge {
         "class"?: string;
@@ -1954,6 +1965,9 @@ declare namespace LocalJSX {
     }
     interface MvxTrim {
         "class"?: string;
+        /**
+          * @default DataTestIdsEnum.trim
+         */
         "dataTestId"?: string;
         "text"?: string;
     }

--- a/src/components/functional/toasts-list/components/transaction-toast/components/transaction-toast-content/transaction-toast-content.scss
+++ b/src/components/functional/toasts-list/components/transaction-toast/components/transaction-toast-content/transaction-toast-content.scss
@@ -1,6 +1,6 @@
 .transaction-toast-content-wrapper {
   @apply mvx:relative mvx:flex mvx:p-3 mvx:flex-col mvx:items-start mvx:gap-1 mvx:rounded-xl mvx:backdrop-blur-2xl mvx:max-w-100;
-  border: 0.5px solid var(--mvx-bg-accent-variant-color);
+  border: 2px solid var(--mvx-border-color-secondary);
   background: var(--mvx-bg-color-primary);
   color: var(--mvx-text-color-primary);
 

--- a/src/global/variables.css
+++ b/src/global/variables.css
@@ -129,8 +129,8 @@
   --mvx-select-option-color: var(--mvx-black);
   --mvx-select-option-bg: var(--mvx-neutral-400);
   --mvx-select-option-bg-mobile: var(--mvx-neutral-400);
-  --mvx-success-color: var(--mvx-white);
-  --mvx-success-bg-color: var(--mvx-green-650);
+  --mvx-success-color: var(--mvx-green-650);
+  --mvx-success-bg-color: var(--mvx-green-850);
   --mvx-pending-color: var(--mvx-yellow-400);
   --mvx-pending-bg-color: var(--mvx-brown-900);
   --mvx-error-color: var(--mvx-red-400);

--- a/src/global/variables.css
+++ b/src/global/variables.css
@@ -31,7 +31,7 @@
   --mvx-stone-150: #e2dedc;
   --mvx-stone-350: #b6b3af;
   --mvx-stone-450: #88817a;
-  --mvx-stone-950: #1B1B1B;
+  --mvx-stone-950: #1c1c1c;
   --mvx-slate-550: #545b62;
   --mvx-green-400: #4ade80;
   --mvx-green-650: #14aa3e;


### PR DESCRIPTION
### Feature
Improve toast visibility by enhancing border styles.

<img width="387" height="127" alt="image" src="https://github.com/user-attachments/assets/79379db5-f647-49eb-959e-5a5fac17efe4" />


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
