### PR TITLE
Display provider name in advanced signing

### DIFF
--- a/src/components/functional/sign-transactions-panel/components/sign-transactions-footer/sign-transactions-footer.tsx
+++ b/src/components/functional/sign-transactions-panel/components/sign-transactions-footer/sign-transactions-footer.tsx
@@ -46,12 +46,14 @@ export class SignTransactionsFooter {
 
   render() {
     const { onCancel, onBack, onNext } = state;
-    const { currentIndex, currentIndexToSign, needsSigning, username, address, explorerLink } = state.commonData;
+    const { currentIndex, currentIndexToSign, needsSigning, username, address, explorerLink, providerName } =
+      state.commonData;
 
     const isFirstTransaction = currentIndex === 0;
     const currentIndexNeedsSigning = currentIndex === currentIndexToSign;
     const currentIndexCannotBeSignedYet = currentIndex > currentIndexToSign;
     const showForwardAction = currentIndexNeedsSigning || currentIndexCannotBeSignedYet;
+    const checkButtonText = providerName ? `Check ${providerName}` : 'Check your device';
 
     return (
       <div class="sign-transactions-footer" data-testid={DataTestIdsEnum.signTransactionsFooter}>
@@ -108,7 +110,7 @@ export class SignTransactionsFooter {
               {showForwardAction ? (
                 <span class="sign-transactions-footer-button-label-wrapper">
                   {this.isWaitingForSignature ? (
-                    <span class="sign-transactions-footer-button-label">Check your device</span>
+                    <span class="sign-transactions-footer-button-label">{checkButtonText}</span>
                   ) : (
                     <span class="sign-transactions-footer-button-label">{needsSigning ? 'Sign' : 'Confirm'}</span>
                   )}


### PR DESCRIPTION
### Issue
- signing with different providers than ledger will display the same `device` message

### Reproduce
Issue exists on version `0.0.32` of sdk-dapp-ui.

### Root cause

### Fix
- display provider name and add fallback to device

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
